### PR TITLE
Fixing ActiveRecord::Migration is not supported error in Rails 5

### DIFF
--- a/lib/generators/templates/has_permalink_migration.rb.erb
+++ b/lib/generators/templates/has_permalink_migration.rb.erb
@@ -1,9 +1,6 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
-  def self.up
+class <%= migration_class_name %> < ActiveRecord::Migration[<%= Rails.version.first(3) %>]
+  def change
     add_column :<%= name.underscore.camelize.tableize %>, :permalink, :string
     add_index :<%= name.underscore.camelize.tableize %>, :permalink
-  end
-  def self.down
-    remove_column :<%= name.underscore.camelize.tableize %>, :permalink
   end
 end


### PR DESCRIPTION
`StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:`

Also changed the migration format to the new `def change`